### PR TITLE
Using workspace dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -573,19 +573,6 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580"
-dependencies = [
- "humantime",
- "is-terminal",
- "log",
- "regex",
- "termcolor",
-]
-
-[[package]]
-name = "env_logger"
 version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13fa619b91fb2381732789fc5de83b45675e882f66623b7d8cb4f643017018d"
@@ -633,15 +620,6 @@ dependencies = [
  "quote 1.0.37",
  "syn 1.0.109",
  "synstructure 0.12.6",
-]
-
-[[package]]
-name = "fastrand"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
-dependencies = [
- "instant",
 ]
 
 [[package]]
@@ -927,15 +905,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "instant"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
-dependencies = [
- "cfg-if 1.0.0",
-]
-
-[[package]]
 name = "inventory"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -963,15 +932,6 @@ name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
-
-[[package]]
-name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
 
 [[package]]
 name = "itertools"
@@ -1414,7 +1374,7 @@ dependencies = [
  "cassowary",
  "compact_str",
  "instability",
- "itertools 0.13.0",
+ "itertools",
  "lru",
  "paste",
  "strum",
@@ -1787,7 +1747,7 @@ dependencies = [
  "anyhow",
  "bincode",
  "const_format",
- "itertools 0.10.5",
+ "itertools",
  "log",
  "serde",
  "task-maker-dag",
@@ -1826,8 +1786,8 @@ dependencies = [
  "blake3",
  "crossbeam-channel",
  "ductile",
- "env_logger 0.10.2",
- "itertools 0.10.5",
+ "env_logger",
+ "itertools",
  "log",
  "nix 0.26.4",
  "pretty_assertions",
@@ -1842,7 +1802,7 @@ dependencies = [
  "thiserror",
  "typescript-definitions",
  "uuid",
- "which 4.4.2",
+ "which",
 ]
 
 [[package]]
@@ -1855,10 +1815,10 @@ dependencies = [
  "askama_derive",
  "blake3",
  "derivative",
- "fastrand 1.9.0",
+ "fastrand",
  "glob",
  "inventory",
- "itertools 0.10.5",
+ "itertools",
  "lazy_static",
  "log",
  "mime_guess",
@@ -1902,7 +1862,7 @@ dependencies = [
  "task-maker-exec",
  "tempfile",
  "typescript-definitions",
- "which 4.4.2",
+ "which",
 ]
 
 [[package]]
@@ -1916,9 +1876,9 @@ dependencies = [
  "clap_complete",
  "ctrlc",
  "directories",
- "env_logger 0.11.5",
- "fastrand 2.2.0",
- "itertools 0.13.0",
+ "env_logger",
+ "fastrand",
+ "itertools",
  "lazy_static",
  "log",
  "num_cpus",
@@ -1939,7 +1899,7 @@ dependencies = [
  "typescript-definitions",
  "url",
  "walkdir",
- "which 7.0.0",
+ "which",
  "whoami",
 ]
 
@@ -1965,7 +1925,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28cce251fcbc87fac86a866eeb0d6c2d536fc16d06f184bb61aeae11aa4cee0c"
 dependencies = [
  "cfg-if 1.0.0",
- "fastrand 2.2.0",
+ "fastrand",
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
@@ -2389,7 +2349,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
 dependencies = [
- "itertools 0.13.0",
+ "itertools",
  "unicode-segmentation",
  "unicode-width",
 ]
@@ -2549,18 +2509,6 @@ checksum = "f6488b90108c040df0fe62fa815cbdee25124641df01814dd7282749234c6112"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "which"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
-dependencies = [
- "either",
- "home",
- "once_cell",
- "rustix",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,63 @@ assets = [
 [badges]
 github = { repository = "olimpiadi-informatica/task-maker-rust", workflow = "Rust" }
 
+[workspace.dependencies]
+anyhow = "1.0"
+approx = "0.5"
+askama = "0.11"
+askama_derive = "0.11"
+better-panic = "0.3"
+bincode = "1.2"
+blake3 = "1.3"
+clap = "4.5"
+clap_complete = "4.5"
+colored = "2"
+const_format = "0.2"
+crossbeam-channel = "0.5.6"
+ctrlc = "3.4"
+derivative = "2.2"
+directories = "5.0"
+ductile = "0.3"
+env_logger = "0.11"
+fastrand = "2.0"
+fslock = "0.2"
+glob = "0.3"
+inventory = "0.3.3"
+itertools = "0.13"
+lazy_static = "1.5"
+log = "0.4"
+mime_guess = "2.0"
+nix = "0.26"
+num_cpus = "1.10"
+paste = "1.0.11"
+pest = "2.1"
+pest_derive = "2.1"
+pretty_assertions = "1.2"
+ratatui = { version = "0.28", default-features = false }
+regex = "1"
+rlimit = "0.10"
+scopeguard = "1.2"
+serde = "1.0"
+serde_json = "1.0"
+serde_yaml = "0.9"
+shell-words = "1.1"
+speculoos = "0.11"
+supports-color = "2"
+tabox = "1"
+tempfile = "3.13"
+termcolor = "1"
+termion = "4"
+thiserror = "1.0"
+unic = "0.9"
+url = "2.5"
+uuid = "1.1"
+walkdir = "2.5"
+which = "7.0"
+whoami = "1.5"
+wildmatch = "2.1.0"
+
+typescript-definitions = { git = "https://github.com/onelson/typescript-definitions", branch = "no-debug-attrs" }
+
 [dependencies]
 task-maker-dag = { path = "./task-maker-dag" }
 task-maker-store = { path = "./task-maker-store" }
@@ -46,55 +103,55 @@ task-maker-lang = { path = "./task-maker-lang" } # needed only by typescriptify
 task-maker-format = { path = "./task-maker-format" }
 
 # Logging and setting up the global logger
-log = "0.4"
-env_logger = "0.11"
+log = { workspace = true }
+env_logger = { workspace = true }
 # Argument parsing
-clap = { version = "4.5", features = ["derive"] }
-clap_complete = "4.5"
-num_cpus = "1.10"
+clap = { workspace = true, features = ["derive"] }
+clap_complete = { workspace = true }
+num_cpus = { workspace = true }
 # Better stacktraces for panics
-better-panic = "0.3"
+better-panic = { workspace = true }
 # Worker and client name
-whoami = "1.5"
+whoami = { workspace = true }
 # Cross-platform cache directory
-directories = "5.0"
+directories = { workspace = true }
 # Generic error utilities
-anyhow = { version = "1.0", features = ["backtrace"] }
+anyhow = { workspace = true, features = ["backtrace"] }
 # Message serialization for UI/sandbox/...
-serde = "1.0"
-serde_json = "1.0"
+serde = { workspace = true }
+serde_json = { workspace = true }
 # Sandbox implementation for --sandbox
-tabox = "1"
+tabox = { workspace = true }
 # Signal handler for ^C
-ctrlc = "3.4"
+ctrlc = { workspace = true }
 # Global constants
-lazy_static = "1.5"
+lazy_static = { workspace = true }
 # General iterator utilities
-itertools = "0.13"
+itertools = { workspace = true }
 # Iterate recursively the files in a directory (used for `task-maker-tools reset`)
-walkdir = "2.5"
+walkdir = { workspace = true }
 # defer! macro
-scopeguard = "1.2"
+scopeguard = { workspace = true }
 # URL parsing for connecting to a remote server
-url = "2.5"
+url = { workspace = true }
 # Temporary directory for sandboxes
-tempfile = "3.13"
+tempfile = { workspace = true }
 # Regex
-regex = "1"
+regex = { workspace = true }
 # setrlimit for setting unlimited stack for the checker in the fuzzer
-rlimit = "0.10"
+rlimit = { workspace = true }
 # Geenrating random numbers (the seed in find-bad-case tool)
-fastrand = "2.0"
+fastrand = { workspace = true }
 # Curses UI
-ratatui = { version = "0.28", default-features = false, features = ["termion"] }
+ratatui = { workspace = true, features = ["termion"] }
 
 # Typescript definition generation
-typescript-definitions = { git = "https://github.com/onelson/typescript-definitions", branch = "no-debug-attrs"}
+typescript-definitions = { workspace = true }
 
 [dev-dependencies]
-approx = "0.5"
+approx = { workspace = true }
 # Resolve executable names in $PATH
-which = "7.0"
+which = { workspace = true }
 
 [[bin]]
 name = "task-maker"

--- a/task-maker-cache/Cargo.toml
+++ b/task-maker-cache/Cargo.toml
@@ -9,16 +9,16 @@ task-maker-dag = { path = "../task-maker-dag" }
 task-maker-store = { path = "../task-maker-store" }
 
 # General iterator utilities
-itertools = "0.10"
+itertools = { workspace = true }
 # Serialization/Deserialization
-serde = { version = "1.0", features = ["derive"] }
-bincode = "1.2"
+serde = { workspace = true, features = ["derive"] }
+bincode = { workspace = true }
 # Generic error utilities
-anyhow = { version = "1.0", features = ["backtrace"] }
+anyhow = { workspace = true, features = ["backtrace"] }
 # Logging
-log = "0.4"
+log = { workspace = true }
 # Compile time string format
-const_format = "0.2"
+const_format = { workspace = true }
 
 [dev-dependencies]
-tempfile = "3.3"
+tempfile = { workspace = true }

--- a/task-maker-dag/Cargo.toml
+++ b/task-maker-dag/Cargo.toml
@@ -6,15 +6,16 @@ edition = "2021"
 
 [dependencies]
 task-maker-store = { path = "../task-maker-store" }
+
 # Serialization/Deserialization
-serde = { version = "1.0", features = ["derive"] }
+serde = { workspace = true, features = ["derive"] }
 # UUID generation
-uuid = { version = "1.1", features = ["v4", "fast-rng", "serde"] }
+uuid = { workspace = true, features = ["v4", "fast-rng", "serde"] }
 # Generic error utilities
-anyhow = { version = "1.0", features = ["backtrace"] }
+anyhow = { workspace = true, features = ["backtrace"] }
 # Typescript definition generation
-typescript-definitions = { git = "https://github.com/onelson/typescript-definitions", branch = "no-debug-attrs"}
+typescript-definitions = { workspace = true }
 
 [dev-dependencies]
-tempfile = "3.3"
-approx = "0.5"
+tempfile = { workspace = true }
+approx = { workspace = true }

--- a/task-maker-diagnostics/Cargo.toml
+++ b/task-maker-diagnostics/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 
 [dependencies]
 # Serialization/Deserialization
-serde = { version = "1.0", features = ["derive"] }
+serde = { workspace = true, features = ["derive"] }
 # Utilities for writing to the terminal with colors
-colored = "2"
+colored = { workspace = true }
 # Generic error utilities
-anyhow = "1"
+anyhow = { workspace = true }

--- a/task-maker-exec/Cargo.toml
+++ b/task-maker-exec/Cargo.toml
@@ -10,36 +10,36 @@ task-maker-store = { path = "../task-maker-store" }
 task-maker-cache = { path = "../task-maker-cache" }
 
 # Generic error utilities
-anyhow = { version = "1.0", features = ["backtrace"] }
-thiserror = "1.0"
+anyhow = { workspace = true, features = ["backtrace"] }
+thiserror = { workspace = true }
 # Serialization/Deserialization
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-bincode = "1.1"
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+bincode = { workspace = true }
 # Logging
-log = "0.4"
+log = { workspace = true }
 # UUID generation
-uuid = { version = "1.1", features = ["v4", "fast-rng", "serde"] }
+uuid = { workspace = true, features = ["v4", "fast-rng", "serde"] }
 # Temporary directory for sandboxes and FIFO directory
-tempfile = "3.3"
+tempfile = { workspace = true }
 # Resolve executable names in $PATH
-which = "4.2"
+which = { workspace = true }
 # General iterator utilities
-itertools = "0.10"
+itertools = { workspace = true }
 # defer! macro
-scopeguard = "1.0"
+scopeguard = { workspace = true }
 # Sandbox
-tabox = "1"
+tabox = { workspace = true }
 # For killing processes and making FIFOs
-nix = "0.26"
+nix = { workspace = true }
 # In-memory and remote channels
-ductile = "0.3"
+ductile = { workspace = true }
 # Key Derivation Function from a password
-blake3 = "1.3"
+blake3 = { workspace = true }
 # Typescript definition generation
-typescript-definitions = { git = "https://github.com/onelson/typescript-definitions", branch = "no-debug-attrs"}
-crossbeam-channel = "0.5.6"
+typescript-definitions = { workspace = true }
+crossbeam-channel = { workspace = true }
 
 [dev-dependencies]
-pretty_assertions = "1.2"
-env_logger = "0.10"
+pretty_assertions = { workspace = true }
+env_logger = { workspace = true }

--- a/task-maker-format/Cargo.toml
+++ b/task-maker-format/Cargo.toml
@@ -11,61 +11,61 @@ task-maker-exec = { path = "../task-maker-exec" }
 task-maker-diagnostics = { path = "../task-maker-diagnostics" }
 
 # Serialization/Deserialization
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-serde_yaml = "0.9"
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+serde_yaml = { workspace = true }
 # Generic error utilities
-anyhow = { version = "1.0", features = ["backtrace"] }
+anyhow = { workspace = true, features = ["backtrace"] }
 # General iterator utilities
-itertools = "0.10"
+itertools = { workspace = true }
 # Utilities for writing to the terminal with colors
-termcolor = "1"
+termcolor = { workspace = true }
 # Checks if the terminal supports the colors
-supports-color = "2"
+supports-color = { workspace = true }
 # Logging
-log = "0.4"
+log = { workspace = true }
 # Globbing files
-glob = "0.3"
+glob = { workspace = true }
 # Text parser for parsing the gen/GEN file
-pest = "2.1"
-pest_derive = "2.1"
+pest = { workspace = true }
+pest_derive = { workspace = true }
 # Curses UI
-ratatui = { version = "0.28", default-features = false, features = ["termion"] }
-termion = "4"
+ratatui = { workspace = true, features = ["termion"] }
+termion = { workspace = true }
 # Global constants
-lazy_static = "1.3"
+lazy_static = { workspace = true }
 # Checking equalness between floats
-approx = "0.5"
+approx = { workspace = true }
 # Regular expressions
-regex = "1"
+regex = { workspace = true }
 # File templating (for building statement tex file)
-askama = "0.11"
-askama_derive = "0.11"
+askama = { workspace = true }
+askama_derive = { workspace = true }
 # Detecting the content type of a file
-mime_guess = "2.0"
+mime_guess = { workspace = true }
 # Geenrating random numbers (the seed in terry)
-fastrand = "1.8"
+fastrand = { workspace = true }
 # Split command line arguments
-shell-words = "1.1"
+shell-words = { workspace = true }
 # Nicer derive macros
-derivative = "2.2"
+derivative = { workspace = true }
 # For sending ^C to the process
-nix = "0.26"
+nix = { workspace = true }
 # Typescript definition generation
-typescript-definitions = { git = "https://github.com/onelson/typescript-definitions", branch = "no-debug-attrs"}
+typescript-definitions = { workspace = true }
 # Unicode for subtask names
-unic = "0.9"
+unic = { workspace = true }
 # Wildcard match for subtask names.
-wildmatch = "2.1.0"
+wildmatch = { workspace = true }
 # Plugin system for the sanity checks.
-inventory = "0.3.3"
+inventory = { workspace = true }
 # For the plugin system.
-paste = "1.0.11"
+paste = { workspace = true }
 # Hashing function
-blake3 = "1.3"
+blake3 = { workspace = true }
 
 [dev-dependencies]
-tempfile = "3.3"
-pretty_assertions = "1.2"
+tempfile = { workspace = true }
+pretty_assertions = { workspace = true }
 # assert_that! macro
-speculoos = "0.11"
+speculoos = { workspace = true }

--- a/task-maker-lang/Cargo.toml
+++ b/task-maker-lang/Cargo.toml
@@ -8,23 +8,24 @@ edition = "2021"
 task-maker-dag = { path = "../task-maker-dag" }
 
 # Serialization/Deserialization
-serde = { version = "1.0", features = ["derive", "rc"] }
+serde = { workspace = true, features = ["derive", "rc"] }
 # Regular expressions
-regex = "1"
+regex = { workspace = true }
 # Generic error utilities
-anyhow = { version = "1.0", features = ["backtrace"] }
+anyhow = { workspace = true, features = ["backtrace"] }
 # Global constants
-lazy_static = "1.3"
+lazy_static = { workspace = true }
 # Resolve executable names in $PATH
-which = "4.2"
+which = { workspace = true }
 # Split command line arguments
-shell-words = "1.1"
+shell-words = { workspace = true }
 # Typescript definition generation
-typescript-definitions = { git = "https://github.com/onelson/typescript-definitions", branch = "no-debug-attrs"}
+typescript-definitions = { workspace = true }
 
 [dev-dependencies]
 task-maker-exec = { path = "../task-maker-exec" }
-tempfile = "3.3"
+
+tempfile = { workspace = true }
 # assert_that! macro
-speculoos = "0.11"
-tabox = "1"
+speculoos = { workspace = true }
+tabox = { workspace = true }

--- a/task-maker-store/Cargo.toml
+++ b/task-maker-store/Cargo.toml
@@ -6,20 +6,20 @@ edition = "2021"
 
 [dependencies]
 # Hashing function
-blake3 = "1.3"
+blake3 = { workspace = true }
 # Generic error utilities
-anyhow = { version = "1.0", features = ["backtrace"] }
+anyhow = { workspace = true, features = ["backtrace"] }
 # File locking
-fslock = "0.2"
+fslock = { workspace = true }
 # Serialization/Deserialization
-serde = { version = "1.0", features = ["derive"] }
-bincode = "1.2"
+serde = { workspace = true, features = ["derive"] }
+bincode = { workspace = true }
 # Logging
-log = "0.4"
+log = { workspace = true }
 # Temporary directory creation
-tempfile = "3.3"
+tempfile = { workspace = true }
 # Compile time string format
-const_format = "0.2"
+const_format = { workspace = true }
 
 [dev-dependencies]
-pretty_assertions = "1.2"
+pretty_assertions = { workspace = true }


### PR DESCRIPTION
Dependabot is not able to update a dependency in multiple crates in a single pull requests, leading to conflicting versions. Using workspace dependencies the issue is avoided.