### PR TITLE
Make task-maker-rust debian packages work on Ubuntu 23.10+.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,8 @@ assets = [
     # vim syntax highlight
     ["tools/vim/ftdetect/cases_gen.vim", "usr/share/vim/vimfiles/ftdetect/cases_gen.vim", "644"],
     ["tools/vim/syntax/cases_gen.vim", "usr/share/vim/vimfiles/syntax/cases_gen.vim", "644"],
+    # AppArmor profile for allowing user namespaces on Ubuntu 23.10+.
+    ["tools/ubuntu/apparmor-task-maker-rust", "etc/apparmor.d/task-maker-rust", "644"]
 ]
 
 [badges]

--- a/task-maker-format/src/ioi/format/italian_yaml/cases_gen.rs
+++ b/task-maker-format/src/ioi/format/italian_yaml/cases_gen.rs
@@ -734,11 +734,7 @@ impl ConstraintOperand {
             ConstraintOperand::Constant(k) => Some(*k),
             ConstraintOperand::Variable(var) => {
                 if let Some(val) = vars.get(var) {
-                    if let Ok(val) = i64::from_str(val) {
-                        Some(val)
-                    } else {
-                        None
-                    }
+                    i64::from_str(val).ok()
                 } else {
                     None
                 }

--- a/tools/ubuntu/apparmor-task-maker-rust
+++ b/tools/ubuntu/apparmor-task-maker-rust
@@ -1,0 +1,10 @@
+# Allow user namespaces for task-maker-rust
+
+abi <abi/4.0>,
+
+profile task-maker-rust /usr/bin/task-maker-tools flags=(default_allow) {
+  userns,
+
+  # Site-specific additions and overrides. See local/README for details.
+  include if exists <local/task-maker-rust>
+}


### PR DESCRIPTION
This commit adds an apparmor configuration file that allows user namespaces for task-maker-rust, un-breaking tmr on newer 'buntus.

Fixes #248